### PR TITLE
fix(d&db): correct typo and narrow the matches of `window.location`

### DIFF
--- a/src/dndbeyond.ts
+++ b/src/dndbeyond.ts
@@ -26,7 +26,7 @@ const DEFAULT_THEME = 'dddice-standard';
  */
 async function init() {
   if (
-    /.*\/(characters|encourner-builder|combat-tracker|encounters)\/.*/.test(window.location.href)
+    /^\/(characters\/.+|my-encounters|encounter-builder|combat-tracker\/.+|encounters\/.+)/.test(window.location.pathname)
   ) {
     log.debug('init');
     // add canvas element to document


### PR DESCRIPTION
Correct typo: "encourner-builder" s/b "encounter-builder"

Narrow regex: match against the beginning of `pathname` (not full `href`):
- `/characters/.+`
- `/my-encounters`
- `/encounter-builder`
- `/combat-tracker/.+`
- `/encounters/.+`
