### PR TITLE
fix(dmv): change load event to listen to, use a consistent url

### DIFF
--- a/src/SdkBridge.ts
+++ b/src/SdkBridge.ts
@@ -22,7 +22,7 @@ export default class SdkBridge {
       return 'D&DBeyond';
     } else if (/roll20.net/.test(tab.url)) {
       return 'Roll20';
-    } else if (/dungeonmastersvault.com/.test(tab.url)) {
+    } else if (/www.dungeonmastersvault.com/.test(tab.url)) {
       return "Dungeon Master's Vault";
     } else if (/dddice.com/.test(tab.url)) {
       return 'dddice';

--- a/src/dungeonmastersvault.ts
+++ b/src/dungeonmastersvault.ts
@@ -395,7 +395,7 @@ window.addEventListener('resize', () => init());
 // Subscribe to any DOM mutations and re-run init. We have to
 // observe the `app` div because the tables don't have IDs.
 const observer = new MutationObserver(() => init());
-document.addEventListener('DOMContentLoaded', () => {
+window.addEventListener('load', () => {
   observer.observe(document.getElementById('app'), {
     attributes: true,
     childList: true,

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -33,7 +33,7 @@
     {
       "js": ["./dungeonmastersvault.ts"],
       "css": ["./dungeonmastersvault.css"],
-      "matches": ["*://*.dungeonmastersvault.com/pages/dnd/5e/*"],
+      "matches": ["*://www.dungeonmastersvault.com/pages/dnd/5e/*"],
       "run_at": "document_idle"
     },
     {


### PR DESCRIPTION
- Listening for `document.DOMContentLoaded` is causing intermittent issues with self-hosted instances (maybe with the official site too?). Switched to `window.load`.
- Using a full URL also makes it easier to modify the extension when self-hosting (one single search/replace).
