### PR TITLE
feat: Added support for tabyltop, custom configuration, character sheet and health features 

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,10 +7,11 @@
   "scripts": {
     "build:manifest_v3": "parcel build src/manifest_v3/manifest.json --dist-dir manifest_v3 --no-cache --no-source-maps",
     "build:manifest_v2": "parcel build src/manifest_v2/manifest.json --dist-dir manifest_v2 --no-cache --no-source-maps",
-    "lint": "eslint .",
+    "lint": "eslint src --fix",
     "start": "parcel watch src/manifest_v3/manifest.json --dist-dir manifest_v3 --host localhost",
     "start:firefox": "parcel watch src/manifest_v2/manifest.json --dist-dir manifest_v2 --host localhost",
-    "prettier": "prettier -l --write src"
+    "prettier": "prettier -l --write src",
+    "check": "npm run prettier && npm run lint"
   },
   "dependencies": {
     "@dice-roller/rpg-dice-roller": "^5.2.1",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "build:manifest_v2": "parcel build src/manifest_v2/manifest.json --dist-dir manifest_v2 --no-cache --no-source-maps",
     "lint": "eslint .",
     "start": "parcel watch src/manifest_v3/manifest.json --dist-dir manifest_v3 --host localhost",
-    "start:firefox": "parcel watch src/manifest_v2/manifest.json --dist-dir manifest_v2 --host localhost"
+    "start:firefox": "parcel watch src/manifest_v2/manifest.json --dist-dir manifest_v2 --host localhost",
+    "prettier": "prettier -l --write src"
   },
   "dependencies": {
     "@dice-roller/rpg-dice-roller": "^5.2.1",

--- a/src/DddiceSettings.tsx
+++ b/src/DddiceSettings.tsx
@@ -147,7 +147,7 @@ const DddiceSettings = (props: DddiceSettingsProps) => {
       sdkBridge.queryCustomConfiguration();
       setTimeout(async () => {
         const customConfiguration = await storageProvider.getStorage('customConfiguration');
-        if (customConfiguration && Date.now() - customConfiguration.lastUpdated <= 500) {
+        if (customConfiguration && Date.now() - customConfiguration.lastUpdated <= 600) {
           setExternalConfiguration(customConfiguration);
         }
         popLoading();

--- a/src/DddiceSettings.tsx
+++ b/src/DddiceSettings.tsx
@@ -22,6 +22,7 @@ import StorageProvider from './StorageProvider';
 import SdkBridge from './SdkBridge';
 import PermissionProvider from './PermissionProvider';
 import Toggle from './components/Toggle';
+import { CustomConfiguration } from './schema/custom_configuration';
 
 const log = createLogger('App');
 
@@ -93,6 +94,9 @@ const DddiceSettings = (props: DddiceSettingsProps) => {
 
   const [isEnterApiKey, setIsEnterApiKey] = useState(false);
 
+  const [externalConfiguration, setExternalConfiguration] = useState<
+    CustomConfiguration | undefined
+  >(undefined);
   /**
    * Connect to VTT
    * Mount / Unmount
@@ -134,6 +138,23 @@ const DddiceSettings = (props: DddiceSettingsProps) => {
 
     if (isConnected) {
       initStorage();
+    }
+  }, [isConnected]);
+
+  useEffect(() => {
+    async function init() {
+      pushLoading();
+      sdkBridge.queryCustomConfiguration();
+      setTimeout(async () => {
+        const customConfiguration = await storageProvider.getStorage('customConfiguration');
+        if (customConfiguration && Date.now() - customConfiguration.lastUpdated <= 500) {
+          setExternalConfiguration(customConfiguration);
+        }
+        popLoading();
+      }, 500);
+    }
+    if (isConnected) {
+      init();
     }
   }, [isConnected]);
 
@@ -399,6 +420,16 @@ const DddiceSettings = (props: DddiceSettingsProps) => {
         <img src={imageLogo} alt="dddice" />
         <span className="text-white text-lg">dddice</span>
       </div>
+      {externalConfiguration && (
+        <div className="flex flex-col space-y-1 items-center justify-center">
+          <span class="text-white text-lg">Configuration is being controlled by</span>
+          <img src={externalConfiguration.icon} alt="configuration system" />
+          <div className="flex flex-col items-center space-y-3">
+            <p class="text-white">You can change your theme there</p>
+            <p className="text-white space-y-2">Room: {(state.room || { name: 'Unknown' }).name}</p>
+          </div>
+        </div>
+      )}
       {error && (
         <div className="text-gray-700 mt-4">
           <p className="text-center text-neon-red">{error}</p>
@@ -407,7 +438,8 @@ const DddiceSettings = (props: DddiceSettingsProps) => {
       {isEnterApiKey ? (
         <ApiKeyEntry onSuccess={onKeySuccess} />
       ) : (
-        isConnected && (
+        isConnected &&
+        !externalConfiguration && (
           <>
             {isLoading ? (
               <div className="flex flex-col justify-center text-gray-700 mt-4">

--- a/src/SdkBridge.ts
+++ b/src/SdkBridge.ts
@@ -9,6 +9,12 @@ export default class SdkBridge {
     });
   }
 
+  queryCustomConfiguration(): void {
+    chrome.tabs.query({}, function (tabs) {
+      tabs.forEach(tab => chrome.tabs.sendMessage(tab.id, { type: 'queryCustomConfiguration' }));
+    });
+  }
+
   preloadTheme(theme: ITheme) {
     chrome.tabs.query({}, function (tabs) {
       tabs.forEach(tab => chrome.tabs.sendMessage(tab.id, { type: 'preloadTheme', theme }));
@@ -28,6 +34,8 @@ export default class SdkBridge {
           resolve('dddice');
         } else if (/pathbuilder2e.com/.test(tab.url)) {
           resolve('Pathbuilder 2e');
+        } else if (/tabyltop.com/.test(tab.url)) {
+          resolve('Tabyltop');
         }
       }),
     );

--- a/src/background.tsx
+++ b/src/background.tsx
@@ -1,0 +1,52 @@
+/** @format */
+import { HealthMessage } from './schema/health_message';
+import { setStorage } from './storage';
+import createLogger from './log';
+
+const log = createLogger('background');
+log.info('Background initialized');
+
+const healthMessageByCharacterId: Record<string, HealthMessage> = {};
+
+function sendMessageToAllTabs(message) {
+  chrome.tabs.query({}, function (tabs) {
+    tabs.forEach(function (tab) {
+      try {
+        chrome.tabs.sendMessage(tab.id, message);
+      } catch (e) {
+        // no-op, they may not be listening
+        log.error("Couldn't send message to tab", e);
+      }
+    });
+  });
+}
+
+chrome.runtime.onMessage.addListener(async function (message, sender, sendResponse) {
+  if (message.type === 'health') {
+    try {
+      healthMessageByCharacterId[message.characterId] = message;
+      sendMessageToAllTabs(message);
+    } catch (e) {
+      log.error("Couldn't send message to tab", e);
+    }
+    sendResponse(true);
+  } else if (message.type === 'healthRequest') {
+    log.info('Got health request', healthMessageByCharacterId);
+    for (const characterId in healthMessageByCharacterId) {
+      sendMessageToAllTabs(healthMessageByCharacterId[characterId]);
+    }
+    sendResponse(true);
+  } else if (message.type === 'enableCustomConfiguration') {
+    log.info('Enabling custom configuration');
+    setStorage({
+      customConfiguration: {
+        ...message.customConfiguration,
+        lastUpdated: Date.now(),
+      },
+    });
+    sendResponse(true);
+  } else {
+    sendResponse(false);
+  }
+  return true;
+});

--- a/src/manifest_v2/manifest.json
+++ b/src/manifest_v2/manifest.json
@@ -17,6 +17,10 @@
     "48": "../assets/dddice-48x48.png",
     "128": "../assets/dddice-128x128.png"
   },
+  "background": {
+    "scripts": ["../background.tsx"],
+    "persistent": false
+  },
   "content_scripts": [
     {
       "js": [
@@ -63,6 +67,15 @@
       ],
       "matches": [
         "*://*.pathbuilder2e.com/*"
+      ],
+      "run_at": "document_idle"
+    },
+    {
+      "js": [
+        "../tabyltop.tsx"
+      ],
+      "matches": [
+        "*://*.tabyltop.com/*"
       ],
       "run_at": "document_idle"
     }

--- a/src/manifest_v3/manifest.json
+++ b/src/manifest_v3/manifest.json
@@ -17,6 +17,10 @@
     "48": "../assets/dddice-48x48.png",
     "128": "../assets/dddice-128x128.png"
   },
+  "background": {
+    "service_worker": "../background.tsx",
+    "type": "module"
+  },
   "content_scripts": [
     {
       "js": [
@@ -63,6 +67,15 @@
       ],
       "matches": [
         "*://*.pathbuilder2e.com/*"
+      ],
+      "run_at": "document_idle"
+    },
+    {
+      "js": [
+        "../tabyltop.tsx"
+      ],
+      "matches": [
+        "*://*.tabyltop.com/*"
       ],
       "run_at": "document_idle"
     }

--- a/src/schema/custom_configuration.ts
+++ b/src/schema/custom_configuration.ts
@@ -1,0 +1,7 @@
+/** @format */
+
+export interface CustomConfiguration {
+  icon: string;
+  name: string;
+  lastUpdated: number;
+}

--- a/src/schema/health_message.ts
+++ b/src/schema/health_message.ts
@@ -1,0 +1,8 @@
+/** @format */
+
+export interface HealthMessage {
+  type: 'health';
+  health: number;
+  tempHealth: number;
+  characterId: string;
+}

--- a/src/tabyltop.tsx
+++ b/src/tabyltop.tsx
@@ -48,7 +48,7 @@ window.addEventListener('message', async function (event) {
     return;
   }
   if (messageData.action === 'configure') {
-    document.body.classList.add('dddice');
+    window.postMessage({ type: 'dddice', action: 'enabled' }, document.location.origin);
 
     const { apiKey, roomSlug, themeID } = messageData;
     const dddice = new ThreeDDice().initialize(null, apiKey, undefined, 'Browser Extension');

--- a/src/tabyltop.tsx
+++ b/src/tabyltop.tsx
@@ -40,7 +40,16 @@ window.addEventListener('message', async function (event) {
     });
     return;
   }
+  if (messageData.action === 'openCharacterSheet') {
+    chrome.runtime.sendMessage({
+      type: 'openCharacterSheet',
+      url: messageData.url,
+    });
+    return;
+  }
   if (messageData.action === 'configure') {
+    document.body.classList.add('dddice');
+
     const { apiKey, roomSlug, themeID } = messageData;
     const dddice = new ThreeDDice().initialize(null, apiKey, undefined, 'Browser Extension');
     const room = await dddice.api.room.get(roomSlug);

--- a/src/tabyltop.tsx
+++ b/src/tabyltop.tsx
@@ -1,0 +1,59 @@
+/** @format */
+
+import createLogger from './log';
+import { ThreeDDice } from 'dddice-js';
+import { setStorage } from './storage';
+import SdkBridge from './SdkBridge';
+
+const log = createLogger('Tabyltop');
+log.info('DDDICE Tabyltop loaded');
+
+chrome.runtime.onMessage.addListener(function (message, sender, sendResponse) {
+  if (message.type === 'health') {
+    window.postMessage(message, document.location.origin);
+    sendResponse(true);
+  } else if (message.type === 'queryCustomConfiguration') {
+    window.postMessage(message, document.location.origin);
+  } else {
+    log.info(message);
+    sendResponse(false);
+  }
+  return true;
+});
+
+window.addEventListener('message', async function (event) {
+  if (event.source !== window) {
+    return;
+  }
+  const messageData = event.data;
+  if (messageData.type !== 'dddice') {
+    return;
+  }
+  if (messageData.action === 'healthRequest') {
+    chrome.runtime.sendMessage({ type: 'healthRequest' });
+    return;
+  }
+  if (messageData.action === 'enableCustomConfiguration') {
+    chrome.runtime.sendMessage({
+      type: 'enableCustomConfiguration',
+      customConfiguration: messageData.customConfiguration,
+    });
+    return;
+  }
+  if (messageData.action === 'configure') {
+    const { apiKey, roomSlug, themeID } = messageData;
+    const dddice = new ThreeDDice().initialize(null, apiKey, undefined, 'Browser Extension');
+    const room = await dddice.api.room.get(roomSlug);
+    const theme = await dddice.api.theme.get(themeID);
+
+    setStorage({ apiKey });
+    setStorage({ room: room.data });
+    setStorage({ theme: theme.data });
+    setStorage({ 'render mode': false });
+    try {
+      new SdkBridge().reloadDiceEngine();
+    } catch (e) {
+      //that's okay, the tabs weren't initialized yet
+    }
+  }
+});


### PR DESCRIPTION
This version

1. Adds support for *.tabyltop.com to recognize the tabyltop vtt
2. Adds support for gathering and syncing health information. This will look for mobile and desktop views for health of the current character and post messages to a background service that will attempt to send this on to all open tabs. (Tabyltop receives this information via its content script and sets the token's health appropriately)
3. Adds support for "VTT controlled configuration". This will show an icon instead of the normal configuration to indicate that the configuration is being handled by the VTT. Tabyltop uses this to set the API key, room and theme to match the player and campaign selected in tabyltop. The settings box will post a message to all tabs querying for custom configuration, and any tab can respond within 500ms to indicate that it is controlling the configuration.
4. Adds support for opening a character sheet 500px wide to the right of the active/focused window


https://github.com/dddice/dddice-browser-extension/assets/1612909/d7563abe-3fe9-4017-b035-d3d7d4248587


https://github.com/dddice/dddice-browser-extension/assets/1612909/0080e72a-8baa-4835-9799-b34588566c31

